### PR TITLE
[enhancement] Fix urllib3 compatibility

### DIFF
--- a/GetFortinetSerialNumber.py
+++ b/GetFortinetSerialNumber.py
@@ -19,13 +19,11 @@ try:
     # For older urllib3 versions
     requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ':HIGH:!DH:!aNULL'
 except AttributeError:
-    # For newer urllib3 versions where DEFAULT_CIPHERS is not directly accessible
+    # For newer urllib3 versions where DEFAULT_CIPHERS is not directly accessible, skip this
     pass
 try:
-    # For older urllib3 versions with pyopenssl support
     requests.packages.urllib3.contrib.pyopenssl.util.ssl_.DEFAULT_CIPHERS += ':HIGH:!DH:!aNULL'
 except AttributeError:
-    # For newer urllib3 versions or when pyopenssl is not available
     pass
 
 

--- a/GetFortinetSerialNumber.py
+++ b/GetFortinetSerialNumber.py
@@ -11,13 +11,21 @@ import ssl
 import requests
 import OpenSSL
 
-# Disable warings of insecure connection for invalid cerificates
+# Disable warnings of insecure connection for invalid certificates
 requests.packages.urllib3.disable_warnings()
 # Allow use of deprecated and weak cipher methods
-requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ':HIGH:!DH:!aNULL'
+# Handle compatibility with different urllib3 versions
 try:
+    # For older urllib3 versions
+    requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ':HIGH:!DH:!aNULL'
+except AttributeError:
+    # For newer urllib3 versions where DEFAULT_CIPHERS is not directly accessible
+    pass
+try:
+    # For older urllib3 versions with pyopenssl support
     requests.packages.urllib3.contrib.pyopenssl.util.ssl_.DEFAULT_CIPHERS += ':HIGH:!DH:!aNULL'
 except AttributeError:
+    # For newer urllib3 versions or when pyopenssl is not available
     pass
 
 
@@ -49,8 +57,8 @@ def parseArgs():
     parser = argparse.ArgumentParser(description="A Python script to extract the serial number of a remote Fortinet device. ")
     parser.add_argument("-H", "--host", default=None, required=True, help='Fortinet target')
     parser.add_argument("-P", "--port", default=443, type=int, required=False, help='Fortinet target')
-    parser.add_argument("-o", "--output-cert", default=None, required=False, help='Ouput PEM certificate.')
-    parser.add_argument("-v", "--verbose", default=False, required=False, action='store_true', help='Ouput PEM certificate.')
+    parser.add_argument("-o", "--output-cert", default=None, required=False, help='Output PEM certificate.')
+    parser.add_argument("-v", "--verbose", default=False, required=False, action='store_true', help='Output PEM certificate.')
     return parser.parse_args()
 
 


### PR DESCRIPTION
- Skip changing default ciphers when there's an error.   
- Fix a few misc typos

The urllib3 v2.0+ update changed its internal structure.  When I ran this I got an error where it was changing default ciphers.  In my limited experience the cipher change wasn't necessary but leaving it in for those that might need it and have a compatible urllib3 version.

Also for fun, here's a super simple version of this you can run in the shell to just extract the common name/FGT serial:
```
openssl s_client -connect 192.168.1.99:443 -servername 192.168.1.99 -showcerts < /dev/null 2>/dev/null | gsed -n '/subject=/s/.*\(CN=[^,]*\).*/\1/p'
```


